### PR TITLE
remove unused class

### DIFF
--- a/FSharp/fsharp.py
+++ b/FSharp/fsharp.py
@@ -40,19 +40,6 @@ def erase_status(view, key):
     view.erase_status(key)
 
 
-class fs_dot(sublime_plugin.WindowCommand):
-    '''Inserts the dot character and opens the autocomplete list.
-    '''
-    def run(self):
-        return
-        view = self.window.active_view()
-        pt = view.sel()[0].b
-        view.run_command('insert', {'characters': '.'})
-        view.sel().clear()
-        view.sel().add(sublime.Region(pt + 1))
-        self.window.run_command('fs_run_fsac', { "cmd": "completion" })
-
-
 class fs_run_fsac(sublime_plugin.WindowCommand):
     '''Runs an fsautocomplete.exe command.
     '''


### PR DESCRIPTION
@rneatherway @rojepp 

I previously made a couple of commits by mistake without asking for review; sorry about that!

This one merely cleans up a class that is no longer used.

Recent changes revolve around smoother integration of completions returned by fsac. Specifically, completions are now offered after ~500ms of idle time while editing. Also, completions will only be calculated if the current caret is after a dot. I suppose that this should happen after other characters, but that isn't implemented yet.