### PR TITLE
fix for invalid path on fedora fsi.exe is not a valid executable

### DIFF
--- a/src/lib/editor.py
+++ b/src/lib/editor.py
@@ -72,13 +72,19 @@ class Editor(object):
     def compiler_path(self):
         if self.compilers_path is None:
             return
-        return os.path.join(self.compilers_path, 'fsc.exe')
+        if sublime.platform() ==  'windows':
+            return os.path.join(self.compilers_path, 'fsc.exe')
+        else:
+            return 'fsharpc'
 
     @property
     def interpreter_path(self):
         if self.compilers_path is None:
             return None
-        return os.path.join(self.compilers_path, 'fsi.exe')
+        if sublime.platform() ==  'windows':
+            return os.path.join(self.compilers_path, 'fsi.exe')
+        else:
+            return 'fsharpi'
 
     def update_project_data(self, fs_file):
         assert isinstance(fs_file, FileInfo), 'wrong argument: %s' % fs_file


### PR DESCRIPTION
Hi, i had to make this fix to get it working on fedora 23, you can pull it down if you like it, i didn't tested it on windows or mac os.
Bye