### PR TITLE
Fail install if F# compiler isn't in PATH

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+if ! (test "command -v fsharpc" || test "command -v fsc")
+then
+  echo "Error: F# compiler not found. Is it installed?" >&2
+  exit 1
+fi
+
 if test "$OS" = "Windows_NT"
 then
   # use .Net


### PR DESCRIPTION
Used `command -v` because it's POSIX standard.
